### PR TITLE
Add the MPC (imported from agimus)

### DIFF
--- a/config/agimus_controller_parameters.yaml
+++ b/config/agimus_controller_parameters.yaml
@@ -1,0 +1,24 @@
+---
+# TODO: SETUP THIS AS I HAVE NO IDEA WHAT I'M DOING...
+agimus_controller_node:
+  ros__parameters:
+    ocp:
+      dt: 0.01
+      horizon_size: 30
+      dt_factor_n_seq:
+        n_steps: [20, 10]
+        factors: [1, 2]
+      armature: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+      max_qp_iter: 200
+      max_iter: 4
+      activate_callback: false
+    publish_debug_data: true
+    constant_delay: false
+    rate: 100.0
+    free_flyer: false
+    collision_as_capsule: false
+    self_collision: false
+    collision_pairs_names: [cp_1]
+    cp_1:
+      first: arm_right_7_link_0
+      second: arm_left_7_link_0

--- a/dependencies/agimus_mpc.repos
+++ b/dependencies/agimus_mpc.repos
@@ -1,0 +1,17 @@
+repositories:
+  coal:
+    type: git
+    url: https://github.com/coal-library/coal
+    version: v3.0.1
+  mim_solvers:
+    type: git
+    url: https://github.com/machines-in-motion/mim_solvers
+    version: v0.1.0
+  agimus_msgs:
+    type: git
+    url: https://github.com/agimus-project/agimus_msgs
+    version: humble-devel
+  agimus_controller:
+    type: git
+    url: https://github.com/agimus-project/agimus_controller.git
+    version: humble-devel

--- a/dependencies/patch/agimus_controller.patch
+++ b/dependencies/patch/agimus_controller.patch
@@ -1,0 +1,111 @@
+diff --git i/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py w/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+index f7ed4bc..12a77d8 100644
+--- i/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
++++ w/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+@@ -3,7 +3,6 @@ import crocoddyl
+ import numpy as np
+ import numpy.typing as npt
+ import pinocchio
+-import colmpc
+ import dataclasses
+ import yaml
+ import pinocchio as pin
+@@ -88,14 +87,14 @@ class ActivationModelWeightedQuad(ActivationModel):
+         return crocoddyl.ActivationModelWeightedQuad(weights)
+ 
+ 
+-@dataclasses.dataclass
+-class ActivationModelQuadExp(ActivationModel):
+-    class_: T.ClassVar[str] = "ActivationModelQuadExp"
+-    alpha: float = 1.0
++# @dataclasses.dataclass
++# class ActivationModelQuadExp(ActivationModel):
++#     class_: T.ClassVar[str] = "ActivationModelQuadExp"
++#     alpha: float = 1.0
+ 
+-    def build(self, data: BuildData, residual: crocoddyl.CostModelResidual):
+-        # float() is required to allow parsing a float in scientific notation.
+-        return colmpc.ActivationModelQuadExp(residual.nr, float(self.alpha))
++#     def build(self, data: BuildData, residual: crocoddyl.CostModelResidual):
++#         # float() is required to allow parsing a float in scientific notation.
++#         return colmpc.ActivationModelQuadExp(residual.nr, float(self.alpha))
+ 
+ 
+ @dataclasses.dataclass
+@@ -167,28 +166,28 @@ class ResidualModelFramePlacement(ResidualModel):
+         return crocoddyl.ResidualModelFramePlacement(data.state, id, pref)
+ 
+ 
+-@dataclasses.dataclass
+-class ResidualDistanceCollision(ResidualModel):
+-    class_: T.ClassVar[str] = "ResidualDistanceCollision"
+-    collision_pair: T.Tuple[str, str]
+-
+-    def build(self, data: BuildData):
+-        assert len(self.collision_pair) == 2
+-        cmodel = data.collision_model
+-        # Check that the collision pair exist in the collision model
+-        # and find its index in the list of collision pairs.
+-        cp = []
+-        for name in self.collision_pair:
+-            assert cmodel.existGeometryName(name), f"Geometry object {name} not found."
+-            cp.append(cmodel.getGeometryId(name))
+-        cp = pinocchio.CollisionPair(*cp)
+-        assert cmodel.existCollisionPair(cp)
+-        id = cmodel.findCollisionPair(cp)
+-        assert id < len(data.collision_model.collisionPairs)
+-        # Build the residual
+-        return colmpc.ResidualDistanceCollision(
+-            data.state, data.actuation.nu, cmodel, id
+-        )
++# @dataclasses.dataclass
++# class ResidualDistanceCollision(ResidualModel):
++#     class_: T.ClassVar[str] = "ResidualDistanceCollision"
++#     collision_pair: T.Tuple[str, str]
++
++#     def build(self, data: BuildData):
++#         assert len(self.collision_pair) == 2
++#         cmodel = data.collision_model
++#         # Check that the collision pair exist in the collision model
++#         # and find its index in the list of collision pairs.
++#         cp = []
++#         for name in self.collision_pair:
++#             assert cmodel.existGeometryName(name), f"Geometry object {name} not found."
++#             cp.append(cmodel.getGeometryId(name))
++#         cp = pinocchio.CollisionPair(*cp)
++#         assert cmodel.existCollisionPair(cp)
++#         id = cmodel.findCollisionPair(cp)
++#         assert id < len(data.collision_model.collisionPairs)
++#         # Build the residual
++#         return colmpc.ResidualDistanceCollision(
++#             data.state, data.actuation.nu, cmodel, id
++#         )
+ 
+ 
+ @dataclasses.dataclass
+diff --git i/agimus_controller_ros/agimus_controller_ros/agimus_controller.py w/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+index 96c9dd5..b75405d 100644
+--- i/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
++++ w/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+@@ -75,7 +75,7 @@ class RobotModelsMixin:
+ 
+         # Get moving joint names from LFC
+         self.moving_joint_names = get_param_from_node(
+-            self, "linear_feedback_controller", "moving_joint_names"
++            self, "lfc", "moving_joint_names"
+         ).string_array_value
+ 
+         self.subscriber_robot_description = self.create_subscription(
+diff --git i/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py w/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
+index f3152d7..c4754e9 100644
+--- i/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
++++ w/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
+@@ -71,7 +71,7 @@ class SimpleTrajectoryPublisher(Node):
+         # ros2 topic info -v /robot_description
+         # ros2 topic info -v /sensor
+         self.moving_joint_names = self.get_param_from_node(
+-            "linear_feedback_controller", "moving_joint_names"
++            "lfc", "moving_joint_names"
+         ).string_array_value
+         self.subscriber_robot_description_ = self.create_subscription(
+             String,

--- a/dependencies/patch/agimus_controller_fix_lfc_name.patch
+++ b/dependencies/patch/agimus_controller_fix_lfc_name.patch
@@ -1,0 +1,26 @@
+diff --git i/agimus_controller_ros/agimus_controller_ros/agimus_controller.py w/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+index 96c9dd5..b75405d 100644
+--- i/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
++++ w/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
+@@ -75,7 +75,7 @@ class RobotModelsMixin:
+ 
+         # Get moving joint names from LFC
+         self.moving_joint_names = get_param_from_node(
+-            self, "linear_feedback_controller", "moving_joint_names"
++            self, "lfc", "moving_joint_names"
+         ).string_array_value
+ 
+         self.subscriber_robot_description = self.create_subscription(
+diff --git i/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py w/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
+index f3152d7..c4754e9 100644
+--- i/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
++++ w/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
+@@ -71,7 +71,7 @@ class SimpleTrajectoryPublisher(Node):
+         # ros2 topic info -v /robot_description
+         # ros2 topic info -v /sensor
+         self.moving_joint_names = self.get_param_from_node(
+-            "linear_feedback_controller", "moving_joint_names"
++            "lfc", "moving_joint_names"
+         ).string_array_value
+         self.subscriber_robot_description_ = self.create_subscription(
+             String,

--- a/dependencies/patch/agimus_controller_remove_colmpc.patch
+++ b/dependencies/patch/agimus_controller_remove_colmpc.patch
@@ -1,7 +1,7 @@
-diff --git i/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py w/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+diff --git c/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py i/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
 index f7ed4bc..12a77d8 100644
---- i/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
-+++ w/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
+--- c/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
++++ i/agimus_controller/agimus_controller/ocp/ocp_croco_generic.py
 @@ -3,7 +3,6 @@ import crocoddyl
  import numpy as np
  import numpy.typing as npt
@@ -83,29 +83,3 @@ index f7ed4bc..12a77d8 100644
  
  
  @dataclasses.dataclass
-diff --git i/agimus_controller_ros/agimus_controller_ros/agimus_controller.py w/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
-index 96c9dd5..b75405d 100644
---- i/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
-+++ w/agimus_controller_ros/agimus_controller_ros/agimus_controller.py
-@@ -75,7 +75,7 @@ class RobotModelsMixin:
- 
-         # Get moving joint names from LFC
-         self.moving_joint_names = get_param_from_node(
--            self, "linear_feedback_controller", "moving_joint_names"
-+            self, "lfc", "moving_joint_names"
-         ).string_array_value
- 
-         self.subscriber_robot_description = self.create_subscription(
-diff --git i/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py w/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
-index f3152d7..c4754e9 100644
---- i/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
-+++ w/agimus_controller_ros/agimus_controller_ros/simple_trajectory_publisher.py
-@@ -71,7 +71,7 @@ class SimpleTrajectoryPublisher(Node):
-         # ros2 topic info -v /robot_description
-         # ros2 topic info -v /sensor
-         self.moving_joint_names = self.get_param_from_node(
--            "linear_feedback_controller", "moving_joint_names"
-+            "lfc", "moving_joint_names"
-         ).string_array_value
-         self.subscriber_robot_description_ = self.create_subscription(
-             String,


### PR DESCRIPTION
This PR aims at adding the necessary tools/explanation/minimal examples in order to add crocoddyl MPC into the LFC and therefore control TIAGO through it.

# DONE:
- [x] Add [agimus controller](https://github.com/agimus-project/agimus_controller/tree/humble-devel) deps;

> [!note]
> I struggled installing all the deps (`colmpc` & co), so I removed `colmpc` from the `agimus_controller` source code (see patch)

- [x] Add agimus controller param file;
- [x] Connect it to the LFC

> [!important]
> The LFC node name is hard coded into the agimus_controller code (as 'linear_feedback_controller'), I added a dirty quick patch to fix it a switch it to 'lfc' (see patch). 
> TODO: submit a PR/Issue to agimus in order to add the LFC node name as ROS parameter

# TODO/WIP:

- [ ] Launch the MPC

> [!note]
> I currently struggle a lot to launch it. A python error inside pinnochio triggers:
> ```shell
> ros2 run agimus_controller_ros agimus_controller_node --ros-args --params-file /home/avaliente/Workspace/tiago_lfc/config/agimus_controller_parameters.yaml
> ...
> ...
> from .pinocchio_pywrap_default import *
> RuntimeError: extension class wrapper for base class hpp::fcl::CollisionObject has not been created yet
> ```

- [ ] Test the control
- [ ] Include as much as possible into launch files
- [ ] Update README accordingly